### PR TITLE
Add the length of the glyph data table to the end of the glyph index table to ease copying

### DIFF
--- a/tools/mcufontencoder/src/export_rlefont.cc
+++ b/tools/mcufontencoder/src/export_rlefont.cc
@@ -77,6 +77,7 @@ static void encode_character_range(std::ostream &out,
             data.insert(data.end(), r.begin(), r.end());
         }
     }
+    offsets.push_back(data.size());
     
     write_const_table(out, data, "uint8_t", "mf_rlefont_" + name + "_glyph_data_" + std::to_string(range_index));
     write_const_table(out, offsets, "uint16_t", "mf_rlefont_" + name + "_glyph_offsets_" + std::to_string(range_index), 4);


### PR DESCRIPTION
Basically applying https://github.com/SHA2017-badge/ugfx/commit/71ee8e77c3d1571ff16b012b64d7af43ffa046a5 to the new upstream version.