### PR TITLE
Fixed usage of FreeRTOS locks

### DIFF
--- a/src/gos/gos_freertos.c
+++ b/src/gos/gos_freertos.c
@@ -30,6 +30,8 @@
 	#error "GOS: Either GFX_OS_NO_INIT or GFX_OS_CALL_UGFXMAIN must be defined for FreeRTOS"
 #endif
 
+PRIVILEGED_DATA static portMUX_TYPE lockMux = portMUX_INITIALIZER_UNLOCKED;
+
 void _gosInit(void)
 {
 	#if GFX_OS_NO_INIT && !GFX_OS_INIT_NO_WARNING

--- a/src/gos/gos_freertos.h
+++ b/src/gos/gos_freertos.h
@@ -84,8 +84,9 @@ extern "C" {
 #define gfxSystemTicks()			xTaskGetTickCount()
 #define gfxMillisecondsToTicks(ms)	((systemticks_t)((ms) / portTICK_PERIOD_MS))
 #define gfxTicksToMilliseconds(ticks)	(ticks * portTICK_PERIOD_MS)
-#define gfxSystemLock()				taskENTER_CRITICAL()
-#define gfxSystemUnlock()			taskEXIT_CRITICAL()
+
+#define gfxSystemLock()				taskENTER_CRITICAL(&lockMux)
+#define gfxSystemUnlock()			taskEXIT_CRITICAL(&lockMux)
 
 void gfxMutexInit(gfxMutex* s);
 #define gfxMutexDestroy(pmutex)		vSemaphoreDelete(*(pmutex))


### PR DESCRIPTION
By adding a static mutex in the GOS abstraction layer for FreeRTOS.