### PR TITLE
Don't detach the toggle source on widget destruction

### DIFF
--- a/src/gwin/gwin_widget.c
+++ b/src/gwin/gwin_widget.c
@@ -418,9 +418,8 @@ void _gwidgetDestroy(GHandle gh) {
 		for(role = 0; role < wvmt->toggleroles; role++) {
 			instance = wvmt->ToggleGet(gw, role);
 			if (instance != GWIDGET_NO_INSTANCE) {
+				printf("widget destroy\n");
 				wvmt->ToggleAssign(gw, role, GWIDGET_NO_INSTANCE);
-				if (!FindToggleUser(instance))
-					geventDetachSource(&gl, ginputGetToggle(instance));
 			}
 		}
 	#endif


### PR DESCRIPTION
AFAICS this source is being reused when creating other widgets later, so
if we detach it when destroying the first widget, a subsequent widget instance
will not receive events.

I encountered this problem when creating a List, then destroying that List,
then creating a new List. The new List did not receive any toggle events.